### PR TITLE
Rename "Mailing" to "Redirect" and add Mailing domain support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shakerquiz/utilities",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shakerquiz/utilities",
-      "version": "0.3.32",
+      "version": "0.3.33",
       "license": "ISC",
       "dependencies": {
         "@yurkimus/cookies": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shakerquiz/utilities",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "author": "yurkimus <yurkimus@gmail.com>",
   "license": "ISC",
   "scripts": {

--- a/source/enumerations/backends.d.ts
+++ b/source/enumerations/backends.d.ts
@@ -3,6 +3,7 @@ export namespace Backends {
     let Games: "Games";
     let Locations: "Locations";
     let Users: "Users";
+    let Integrations: "Integrations";
 }
 export namespace BackendFeatures {
     let Backend_1: ("City" | "Game" | "Registration" | "Theme" | "User" | "Venue" | "Checkin")[];
@@ -13,4 +14,6 @@ export namespace BackendFeatures {
     export { Locations_1 as Locations };
     let Users_1: ("User" | "Checkin")[];
     export { Users_1 as Users };
+    let Integrations_1: any[];
+    export { Integrations_1 as Integrations };
 }

--- a/source/enumerations/backends.js
+++ b/source/enumerations/backends.js
@@ -6,6 +6,7 @@ export var Backends = /** @type {const} */ ({
   Games: 'Games',
   Locations: 'Locations',
   Users: 'Users',
+  Integrations: 'Integrations',
 })
 
 export var BackendFeatures = {
@@ -33,5 +34,10 @@ export var BackendFeatures = {
   [Backends.Users]: [
     Domains.User,
     Procedures.Checkin,
+  ],
+
+  [Backends.Integrations]: [
+    Domains.Mailing,
+    Procedures.Redirect,
   ],
 }

--- a/source/enumerations/domains.d.ts
+++ b/source/enumerations/domains.d.ts
@@ -5,6 +5,7 @@ export namespace Domains {
     let Theme: "Theme";
     let User: "User";
     let Venue: "Venue";
+    let Mailing: "Mailing";
 }
 /**
  * @type {Record<Domain, Icon>}

--- a/source/enumerations/domains.js
+++ b/source/enumerations/domains.js
@@ -10,6 +10,7 @@ export var Domains = /** @type {const} */ ({
   Theme: 'Theme',
   User: 'User',
   Venue: 'Venue',
+  Mailing: 'Mailing',
 })
 
 /**
@@ -22,6 +23,7 @@ export var DomainIcons = {
   [Domains.Theme]: Icons['document-text'],
   [Domains.User]: Icons['users'],
   [Domains.Venue]: Icons['map-pin'],
+  [Domains.Mailing]: Icons['envelope'],
 }
 
 /**
@@ -56,6 +58,11 @@ export var DomainKindPathnames = {
   [Domains.Venue]: {
     [Kinds.Unit]: '/venue/:venue?',
     [Kinds.Set]: '/venues',
+  },
+
+  [Domains.Mailing]: {
+    [Kinds.Unit]: '/mailing/:mailing?',
+    [Kinds.Set]: '/mailings',
   },
 }
 
@@ -109,6 +116,15 @@ export var DomainMethodRequirements = {
   },
 
   [Domains.Venue]: {
+    [Methods.DELETE]: new Set([Requirements.Checkin]),
+    [Methods.GET]: new Set([Requirements.Checkin]),
+    [Methods.OPTIONS]: new Set([]),
+    [Methods.PATCH]: new Set([Requirements.Checkin, Requirements.Body]),
+    [Methods.POST]: new Set([Requirements.Checkin, Requirements.Body]),
+    [Methods.PUT]: new Set([Requirements.Checkin, Requirements.Body]),
+  },
+
+  [Domains.Mailing]: {
     [Methods.DELETE]: new Set([Requirements.Checkin]),
     [Methods.GET]: new Set([Requirements.Checkin]),
     [Methods.OPTIONS]: new Set([]),

--- a/source/enumerations/features.d.ts
+++ b/source/enumerations/features.d.ts
@@ -1,6 +1,6 @@
 export const Features: {
     Checkin: "Checkin";
-    Mailing: "Mailing";
+    Redirect: "Redirect";
     '404': "404";
     Exception: "Exception";
     Home: "Home";
@@ -11,6 +11,7 @@ export const Features: {
     Theme: "Theme";
     User: "User";
     Venue: "Venue";
+    Mailing: "Mailing";
 };
 /**
  * @type {Record<Feature, Icon>}

--- a/source/enumerations/procedures.d.ts
+++ b/source/enumerations/procedures.d.ts
@@ -1,6 +1,6 @@
 export namespace Procedures {
     let Checkin: "Checkin";
-    let Mailing: "Mailing";
+    let Redirect: "Redirect";
 }
 /**
  * @type {Record<Procedure, Icon>}

--- a/source/enumerations/procedures.js
+++ b/source/enumerations/procedures.js
@@ -1,11 +1,11 @@
-import { Icons } from './icons.js'
-import { Kinds } from './kinds.js'
-import { Methods } from './methods.js'
-import { Requirements } from './requirements.js'
+import {Icons} from './icons.js'
+import {Kinds} from './kinds.js'
+import {Methods} from './methods.js'
+import {Requirements} from './requirements.js'
 
 export var Procedures = /** @type {const} */ ({
   Checkin: 'Checkin',
-  Mailing: 'Mailing',
+  Redirect: 'Redirect',
 })
 
 /**
@@ -13,7 +13,7 @@ export var Procedures = /** @type {const} */ ({
  */
 export var ProcedureIcons = {
   [Procedures.Checkin]: Icons['arrow-right-end-on-rectangle'],
-  [Procedures.Mailing]: Icons['envelope'],
+  [Procedures.Redirect]: Icons['no-symbol'],
 }
 
 /**
@@ -25,9 +25,9 @@ export var ProcedureKindPathnames = {
     [Kinds.Set]: '/checkins',
   },
 
-  [Procedures.Mailing]: {
-    [Kinds.Unit]: '/mailing',
-    [Kinds.Set]: '/mailings',
+  [Procedures.Redirect]: {
+    [Kinds.Unit]: '/redirect',
+    [Kinds.Set]: '/redirects',
   },
 }
 
@@ -44,12 +44,7 @@ export var ProcedureMethodRequirements = {
     [Methods.PUT]: new Set([]),
   },
 
-  [Procedures.Mailing]: {
-    [Methods.DELETE]: new Set([]),
+  [Procedures.Redirect]: {
     [Methods.GET]: new Set([]),
-    [Methods.OPTIONS]: new Set([]),
-    [Methods.PATCH]: new Set([]),
-    [Methods.POST]: new Set([Requirements.Body]),
-    [Methods.PUT]: new Set([Requirements.Body]),
   },
 }

--- a/source/enumerations/procedures.js
+++ b/source/enumerations/procedures.js
@@ -1,7 +1,7 @@
-import {Icons} from './icons.js'
-import {Kinds} from './kinds.js'
-import {Methods} from './methods.js'
-import {Requirements} from './requirements.js'
+import { Icons } from './icons.js'
+import { Kinds } from './kinds.js'
+import { Methods } from './methods.js'
+import { Requirements } from './requirements.js'
 
 export var Procedures = /** @type {const} */ ({
   Checkin: 'Checkin',


### PR DESCRIPTION
### Description

This pull request:
- Renames the "Mailing" procedure to "Redirect" and updates all associated paths, icons, and methods.
- Introduces a new "Mailing" domain with unique configurations, including updated paths, icons, and method requirements.
- Adds backend support for the "Integrations" service.

### Checklist

- [ ] Update documentation for changes.
- [ ] Test the new "Mailing" domain functionality thoroughly.
- [ ] Verify integration with backend services.