### PR TITLE
Register vkma registration creation routes

### DIFF
--- a/source/entities/routes.js
+++ b/source/entities/routes.js
@@ -73,6 +73,8 @@ export const Routes = Object.freeze(
     'registration/creation',
     'registration/creation/landing/team',
     'registration/creation/landing/group',
+    'registration/creation/vkma/team',
+    'registration/creation/vkma/group',
     'registration/confirmation',
     'registration/cancellation',
     'registration/lineup/search',

--- a/source/entities/segment.js
+++ b/source/entities/segment.js
@@ -313,6 +313,17 @@ export const Segments = Object.freeze(
     ),
     Object.freeze(
       /** @type {const} */ ({
+        key: 'vkma',
+        cardinality: '1',
+        singular: 'vkma',
+        plural: 'vkmas',
+        service: null,
+        pattern: null,
+        kind: 'Integration',
+      }),
+    ),
+    Object.freeze(
+      /** @type {const} */ ({
         key: 'team',
         cardinality: '1',
         singular: 'team',


### PR DESCRIPTION
## Summary

Introduces the `vkma` registration-creation source so the VK Mini App can move onto the route-based `registration/creation/{source}/{kind}` design (alongside the existing `landing` source).

## Changes
- `source/entities/segment.js` — new `vkma` source segment, mirroring `landing` (`service: null`, `kind: 'Integration'`, `pattern: null`, `cardinality: '1'`). The route's service is resolved from the head `registration` segment, so `vkma` carries no service of its own.
- `source/entities/routes.js` — registers `registration/creation/vkma/team` and `registration/creation/vkma/group`.

## Why
The route declares the business process: a vkma-sourced creation is known to be a Vkontakte channel, so the downstream registrations handlers stamp `channel`/`confirmed_channel` in code instead of trusting the client. Consumers (services/registrations, services/updates) depend on this segment to resolve and broadcast the new routes.