### PR TITLE
Add hub segment

### DIFF
--- a/source/entities/segment.js
+++ b/source/entities/segment.js
@@ -324,6 +324,17 @@ export const Segments = Object.freeze(
     ),
     Object.freeze(
       /** @type {const} */ ({
+        key: 'hub',
+        cardinality: '1',
+        singular: 'hub',
+        plural: 'hubs',
+        service: null,
+        pattern: null,
+        kind: 'Integration',
+      }),
+    ),
+    Object.freeze(
+      /** @type {const} */ ({
         key: 'team',
         cardinality: '1',
         singular: 'team',


### PR DESCRIPTION
Register `hub` alongside `landing` and `vkma` so a route can name the hub as the source of a business process — for example `registration/confirmation/hub`.

`service` and `pattern` are null, matching `landing` and `vkma`: the hub is where an action comes from, not a service we call, and not a route parameter.